### PR TITLE
Updated Dependency Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git@github.com:visionmedia/connect-redis.git"
   },
   "dependencies": {
-    "debug": "^2.2.0",
+    "debug": "^3.1.0",
     "redis": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Debug needs to be at least version 2.6.9 - when the ReDoS vulnerability was patched.

Note: all tests and debug tests were run to ensure this didn't break anything. All seems to be good, 64/64 passed on both sets.